### PR TITLE
Implemented debouncing of interrupts (Github Issue 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ $pin->setEdge(InputPinInterface::EDGE_BOTH);
 // Create an interrupt watcher
 $interruptWatcher = $gpio->createWatcher();
 
-// Register a callback to be triggered on pin interrupts
+// Register a callback to be triggered on pin interrupts with a 500 millisecond debounce delay
 $interruptWatcher->register($pin, function (InputPinInterface $pin, $value) {
     echo 'Pin ' . $pin->getNumber() . ' changed to: ' . $value . PHP_EOL;
 
     // Returning false will make the watcher return false immediately
     return true;
-});
+}, 500);
 
 // Watch for interrupts, timeout after 5000ms (5 seconds)
 while ($interruptWatcher->watch(5000));

--- a/src/Interrupt/InterruptWatcherInterface.php
+++ b/src/Interrupt/InterruptWatcherInterface.php
@@ -11,8 +11,9 @@ interface InterruptWatcherInterface
      *
      * @param InputPinInterface $pin
      * @param callable $callback
+     * @param integer $delay time in ms between callbacks
      */
-    public function register(InputPinInterface $pin, callable $callback);
+    public function register(InputPinInterface $pin, callable $callback, int $delay = 0);
 
     /**
      * Unregister a pin callback.


### PR DESCRIPTION
Implemented as per the suggestion in that thread.
Updated README.md.
Unit tests need additional coverage to cover debounce and migrating to cover later versions of PHPUnit.